### PR TITLE
docs(swagger): Añade documentación Swagger

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -14,6 +14,40 @@ const options = {
         description: 'Servidor de desarrollo',
       },
     ],
+    tags: [
+      { name: 'Auth', description: 'Registro e inicio de sesión' },
+      {
+        name: 'Users',
+        description: 'Perfil, economía, cartas y mazos del usuario autenticado',
+      },
+      {
+        name: 'Friends',
+        description: 'Gestión de amigos y solicitudes de amistad',
+      },
+      { name: 'Lobbies', description: 'Creación y búsqueda de salas de juego' },
+      { name: 'Shop', description: 'Catálogo de artículos y compras' },
+      { name: 'Collections', description: 'Colecciones de cartas del juego' },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        Error: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              example: 'Mensaje de error descriptivo.',
+            },
+          },
+        },
+      },
+    },
   },
   apis: ['./src/routes/*.ts'], // Aquí es donde Swagger buscará los comentarios para documentar
 };

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -5,7 +5,138 @@ import { login, register } from '../controllers';
 
 const router = Router();
 
+/**
+ * @swagger
+ * /api/auth/register:
+ *   post:
+ *     summary: Registrar un nuevo usuario
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - username
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: jugador@ejemplo.com
+ *               username:
+ *                 type: string
+ *                 example: jugador42
+ *               password:
+ *                 type: string
+ *                 format: password
+ *                 example: MiPassword123!
+ *     responses:
+ *       201:
+ *         description: Usuario registrado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Usuario registrado exitosamente.
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: u_abc123
+ *                     username:
+ *                       type: string
+ *                       example: jugador42
+ *                     email:
+ *                       type: string
+ *                       example: jugador@ejemplo.com
+ *       400:
+ *         description: Datos inválidos o usuario ya existente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.post('/register', register);
+
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: Iniciar sesión con email y contraseña
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: jugador@ejemplo.com
+ *               password:
+ *                 type: string
+ *                 format: password
+ *                 example: MiPassword123!
+ *     responses:
+ *       200:
+ *         description: Inicio de sesión exitoso, devuelve token JWT
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Inicio de sesión exitoso.
+ *                 token:
+ *                   type: string
+ *                   example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: u_abc123
+ *                     username:
+ *                       type: string
+ *                       example: jugador42
+ *       400:
+ *         description: Faltan campos obligatorios
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: Credenciales inválidas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.post('/login', login);
 
 export default router;

--- a/src/routes/collection.routes.ts
+++ b/src/routes/collection.routes.ts
@@ -10,7 +10,132 @@ const router = Router();
 // Lo mantenemos con auth para seguir tu patrón.
 router.use(authenticate);
 
+/**
+ * @swagger
+ * /api/collections:
+ *   get:
+ *     summary: Obtener todas las colecciones (expansiones y sets) del juego
+ *     tags: [Collections]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de colecciones disponibles
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 collections:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: col_set1
+ *                       name:
+ *                         type: string
+ *                         example: Set Inicial
+ *                       description:
+ *                         type: string
+ *                         example: La colección de inicio que incluye las cartas básicas del juego.
+ *                       releaseDate:
+ *                         type: string
+ *                         format: date
+ *                       totalCards:
+ *                         type: integer
+ *                         example: 100
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/', getCollections);
+
+/**
+ * @swagger
+ * /api/collections/{collectionId}/cards:
+ *   get:
+ *     summary: Obtener todas las cartas pertenecientes a una colección
+ *     tags: [Collections]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: collectionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de la colección (debe comenzar con "col_")
+ *         example: col_set1
+ *     responses:
+ *       200:
+ *         description: Colección y sus cartas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 collection:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: col_set1
+ *                     name:
+ *                       type: string
+ *                       example: Set Inicial
+ *                 cards:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: col_set1_card_001
+ *                       name:
+ *                         type: string
+ *                         example: Dragón de Fuego
+ *                       type:
+ *                         type: string
+ *                         example: Ataque
+ *                       rarity:
+ *                         type: string
+ *                         example: Rara
+ *       400:
+ *         description: ID de colección con formato inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Colección no encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get(
   '/:collectionId/cards',
   validateIdParam('collectionId'),

--- a/src/routes/friend.routes.ts
+++ b/src/routes/friend.routes.ts
@@ -19,15 +19,283 @@ const router = Router();
 
 router.use(authenticate);
 
+/**
+ * @swagger
+ * /api/friends:
+ *   get:
+ *     summary: Obtener la lista de amigos confirmados del usuario autenticado
+ *     tags: [Friends]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de amigos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 friends:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: u_abc123
+ *                       username:
+ *                         type: string
+ *                         example: amigo99
+ *                       status:
+ *                         type: string
+ *                         example: online
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/', getFriends);
+
+/**
+ * @swagger
+ * /api/friends/requests:
+ *   get:
+ *     summary: Obtener las solicitudes de amistad pendientes recibidas
+ *     tags: [Friends]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Solicitudes de amistad pendientes
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 pendingRequests:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: req_def456
+ *                       fromUserId:
+ *                         type: string
+ *                         example: u_abc123
+ *                       toUserId:
+ *                         type: string
+ *                         example: u_xyz789
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *   post:
+ *     summary: Enviar una solicitud de amistad a otro usuario
+ *     tags: [Friends]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - targetUserId
+ *             properties:
+ *               targetUserId:
+ *                 type: string
+ *                 description: ID del usuario destinatario (debe comenzar con "u_")
+ *                 example: u_xyz789
+ *     responses:
+ *       201:
+ *         description: Solicitud de amistad enviada con éxito
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Solicitud de amistad enviada con éxito.
+ *                 request:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: req_def456
+ *                     fromUserId:
+ *                       type: string
+ *                       example: u_abc123
+ *                     toUserId:
+ *                       type: string
+ *                       example: u_xyz789
+ *       400:
+ *         description: ID inválido, la solicitud ya existe o ya son amigos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/requests', getPendingRequests);
 router.post('/requests', validateSendRequestBody, sendRequest);
+
+/**
+ * @swagger
+ * /api/friends/requests/{requestId}:
+ *   put:
+ *     summary: Aceptar o rechazar una solicitud de amistad
+ *     tags: [Friends]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: requestId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID de la solicitud de amistad (debe comenzar con "req_")
+ *         example: req_def456
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - action
+ *             properties:
+ *               action:
+ *                 type: string
+ *                 enum: [accept, reject]
+ *                 example: accept
+ *     responses:
+ *       200:
+ *         description: Solicitud procesada correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Solicitud de amistad aceptada. Ahora son amigos.
+ *       400:
+ *         description: Acción o ID inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: No tienes permiso para responder a esta solicitud
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Solicitud de amistad no encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.put(
   '/requests/:requestId',
   validateIdParam('requestId'),
   validateRespondRequestBody,
   respondToRequest,
 ); // accept o reject
+
+/**
+ * @swagger
+ * /api/friends/{friendId}:
+ *   delete:
+ *     summary: Eliminar un amigo de la lista de amigos
+ *     tags: [Friends]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: friendId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID del amigo a eliminar (debe comenzar con "u_")
+ *         example: u_abc123
+ *     responses:
+ *       200:
+ *         description: Amigo eliminado correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Amigo eliminado correctamente de tu lista.
+ *       400:
+ *         description: ID inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.delete('/:friendId', validateIdParam('friendId'), removeFriend);
 
 export default router;

--- a/src/routes/lobby.routes.ts
+++ b/src/routes/lobby.routes.ts
@@ -9,8 +9,237 @@ const router = Router();
 
 router.use(authenticate);
 
+{
+    "message": "Sala creada exitosamente. Listo para conexión WebSocket.",
+    "lobby": {
+        "_id": "db_id_12345",
+        "hostId": "user_123",
+        "name": "Mi Super Partida",
+        "maxPlayers": 4,
+        "engine": "Classic",
+        "isPrivate": false,
+        "lobbyCode": "NGPN",
+        "status": "waiting",
+        "players": [
+            "user_123"
+        ],
+        "createdAt": "2026-03-02T14:59:44.829Z"
+    }
+}
+/**
+ * @swagger
+ * /api/lobbies:
+ *   post:
+ *     summary: Crear una nueva sala de juego
+ *     tags: [Lobbies]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - maxPlayers
+ *               - engine
+ *               - isPrivate
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: Mi Super Partida
+ *               maxPlayers:
+ *                 type: integer
+ *                 minimum: 3
+ *                 maximum: 6
+ *                 example: 4
+ *               engine:
+ *                 type: string
+ *                 enum: [Classic, Stella]
+ *                 example: Classic
+ *               isPrivate:
+ *                 type: boolean
+ *                 example: false
+ *     responses:
+ *       201:
+ *         description: Sala creada exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Sala creada exitosamente. Listo para conexión WebSocket.
+ *                 lobby:
+ *                   type: object
+ *                   properties:
+ *                     _id:
+ *                       type: string
+ *                       example: db_id_12345
+ *                     hostId:
+ *                       type: string
+ *                       example: user_123
+ *                     name:
+ *                       type: string
+ *                       example: Mi Super Partida
+ *                     maxPlayers:
+ *                       type: integer
+ *                       example: 4
+ *                     engine:
+ *                       type: string
+ *                       example: Classic
+ *                     isPrivate:
+ *                       type: boolean
+ *                       example: false
+ *                     lobbyCode:
+ *                       type: string
+ *                       example: QIXQ
+ *                     status:
+ *                       type: string
+ *                       example: waiting
+ *                     players:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                       example: ["user_123"]
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *                       example: "2026-03-02T14:48:00.497Z"
+ *       400:
+ *         description: Datos de la sala inválidos
+ *       401:
+ *         description: No autenticado
+ *       500:
+ *         description: Error interno del servidor
+ */
 router.post('/', validateCreateLobbyBody, createLobby);
+
+/**
+ * @swagger
+ * /api/lobbies:
+ *   get:
+ *     summary: Obtener la lista de salas públicas disponibles
+ *     tags: [Lobbies]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: Texto para filtrar salas por nombre
+ *         example: Novatos
+ *     responses:
+ *       200:
+ *         description: Lista de salas públicas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 lobbies:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       lobbyCode:
+ *                         type: string
+ *                         example: A1B2
+ *                       name:
+ *                         type: string
+ *                         example: Sala de Novatos
+ *                       hostId:
+ *                         type: string
+ *                         example: u_111
+ *                       players:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                         example: ["u_111", "u_222"]
+ *                       maxPlayers:
+ *                         type: integer
+ *                         example: 4
+ *                       engine:
+ *                         type: string
+ *                         example: Classic
+ *                       status:
+ *                         type: string
+ *                         example: waiting
+ *       401:
+ *         description: No autenticado
+ *       500:
+ *         description: Error interno del servidor
+ */
 router.get('/', getPublicLobbies);
-router.get('/:lobbyCode', validateIdParam('lobbyCode'), getLobbyByCode); // Búsqueda exacta por código
+
+/**
+ * @swagger
+ * /api/lobbies/{lobbyCode}:
+ *   get:
+ *     summary: Obtener los detalles de una sala por su código
+ *     tags: [Lobbies]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: lobbyCode
+ *         required: true
+ *         schema:
+ *           type: string
+ *           pattern: '^[A-Z0-9]{4,6}$'
+ *         description: Código alfanumérico de la sala (4-6 caracteres)
+ *         example: A1B2
+ *     responses:
+ *       200:
+ *         description: Sala encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Sala encontrada.
+ *                 lobby:
+ *                   type: object
+ *                   properties:
+ *                     lobbyCode:
+ *                       type: string
+ *                       example: A1B2
+ *                     name:
+ *                       type: string
+ *                       example: Sala de Novatos
+ *                     hostId:
+ *                       type: string
+ *                       example: u_111
+ *                     players:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                       example: ["u_111", "u_222"]
+ *                     maxPlayers:
+ *                       type: integer
+ *                       example: 4
+ *                     engine:
+ *                       type: string
+ *                       example: Classic
+ *                     isPrivate:
+ *                       type: boolean
+ *                       example: false
+ *                     status:
+ *                       type: string
+ *                       example: waiting
+ *       400:
+ *         description: Código de sala con formato inválido
+ *       403:
+ *         description: La sala está llena
+ *       404:
+ *         description: La sala no existe
+ */
+router.get('/:lobbyCode', validateIdParam('lobbyCode'), getLobbyByCode);
 
 export default router;

--- a/src/routes/lobby.routes.ts
+++ b/src/routes/lobby.routes.ts
@@ -9,23 +9,6 @@ const router = Router();
 
 router.use(authenticate);
 
-{
-    "message": "Sala creada exitosamente. Listo para conexión WebSocket.",
-    "lobby": {
-        "_id": "db_id_12345",
-        "hostId": "user_123",
-        "name": "Mi Super Partida",
-        "maxPlayers": 4,
-        "engine": "Classic",
-        "isPrivate": false,
-        "lobbyCode": "NGPN",
-        "status": "waiting",
-        "players": [
-            "user_123"
-        ],
-        "createdAt": "2026-03-02T14:59:44.829Z"
-    }
-}
 /**
  * @swagger
  * /api/lobbies:

--- a/src/routes/shop.routes.ts
+++ b/src/routes/shop.routes.ts
@@ -116,7 +116,7 @@ router.get('/items', getShopItems);
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/Error'
- *       402:
+ *       403:
  *         description: Saldo insuficiente para realizar la compra
  *         content:
  *           application/json:

--- a/src/routes/shop.routes.ts
+++ b/src/routes/shop.routes.ts
@@ -9,7 +9,148 @@ const router = Router();
 
 router.use(authenticate);
 
+/**
+ * @swagger
+ * /api/shop/items:
+ *   get:
+ *     summary: Obtener el catálogo de artículos disponibles en la tienda
+ *     tags: [Shop]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de artículos disponibles en la tienda
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: item_wildcard_001
+ *                       name:
+ *                         type: string
+ *                         example: Comodín de ataque
+ *                       description:
+ *                         type: string
+ *                         example: Permite cambiar las cartas de ataque una vez por partida.
+ *                       type:
+ *                        type: string
+ *                        example: thematic_deck
+ *                       price:
+ *                         type: number
+ *                         example: 200
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/items', getShopItems);
+
+/**
+ * @swagger
+ * /api/shop/buy:
+ *   post:
+ *     summary: Comprar un artículo de la tienda
+ *     tags: [Shop]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - itemId
+ *             properties:
+ *               itemId:
+ *                 type: string
+ *                 description: ID del artículo a comprar
+ *                 example: item_wildcard_001
+ *     responses:
+ *       200:
+ *         description: Artículo comprado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Has comprado 'Comodín de ataque' exitosamente."
+ *                 updatedBalance:
+ *                   type: object
+ *                   properties:
+ *                     userId:
+ *                       type: string
+ *                       example: user_123
+ *                     coins:
+ *                       type: integer
+ *                       example: 500
+ *                     gems:
+ *                       type: integer
+ *                       example: 50
+ *       400:
+ *         description: itemId inválido o el usuario ya posee el artículo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       402:
+ *         description: Saldo insuficiente para realizar la compra
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Saldo insuficiente.
+ *                 required:
+ *                   type: number
+ *                   example: 200
+ *                 currentBalance:
+ *                   type: number
+ *                   example: 50
+ *       404:
+ *         description: Artículo no encontrado en el catálogo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       409:
+ *         description: Hay una transacción en curso, reintentar más tarde
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno en la transacción
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.post(
   '/buy',
   validateBuyItemBody, // ¿El ID del item es válido y viene en el body?

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -24,19 +24,480 @@ const router = Router();
 
 router.use(authenticate);
 
-// Perfil y economía
+/**
+ * @swagger
+ * /api/users/profile:
+ *   get:
+ *     summary: Obtener el perfil del usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Perfil del usuario
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 profile:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: u_abc123
+ *                     username:
+ *                       type: string
+ *                       example: jugador42
+ *                     email:
+ *                       type: string
+ *                       example: jugador@ejemplo.com
+ *                     createdAt:
+ *                       type: string
+ *                       format: date-time
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Perfil no encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/profile', getProfile);
+
+/**
+ * @swagger
+ * /api/users/balance:
+ *   get:
+ *     summary: Obtener el balance económico del usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Balance actual del usuario
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 balance:
+ *                   type: number
+ *                   example: 1500
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/balance', getBalance);
+
+/**
+ * @swagger
+ * /api/users/inventory:
+ *   get:
+ *     summary: Obtener el inventario de comodines del usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Inventario de comodines del usuario
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 inventory:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       itemId:
+ *                         type: string
+ *                         example: item_wildcard_001
+ *                       name:
+ *                         type: string
+ *                         example: Comodín de ataque
+ *                       quantity:
+ *                         type: integer
+ *                         example: 3
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/inventory', getInventory);
+
+/**
+ * @swagger
+ * /api/users/search:
+ *   get:
+ *     summary: Buscar usuarios por nombre
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: q
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Texto de búsqueda para encontrar usuarios por nombre
+ *         example: jugador
+ *     responses:
+ *       200:
+ *         description: Lista de usuarios que coinciden con la búsqueda
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 results:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: u_abc123
+ *                       username:
+ *                         type: string
+ *                         example: jugador42
+ *       400:
+ *         description: Falta el parámetro de búsqueda
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/search', searchUsers);
 
-// Gestión de Colección Personal y Mazos
+/**
+ * @swagger
+ * /api/users/cards:
+ *   get:
+ *     summary: Obtener las cartas que posee el usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Colección de cartas del usuario
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 cards:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       cardId:
+ *                         type: string
+ *                         example: col_set1_card_042
+ *                       name:
+ *                         type: string
+ *                         example: Dragón de Fuego
+ *                       quantity:
+ *                         type: integer
+ *                         example: 2
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/cards', getOwnedCards);
+
+/**
+ * @swagger
+ * /api/users/decks:
+ *   get:
+ *     summary: Obtener los mazos del usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de mazos del usuario
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 decks:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: d_xyz789
+ *                       name:
+ *                         type: string
+ *                         example: Mazo Velocidad
+ *                       cardIds:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                         example: ["col_set1_card_001", "col_set1_card_002"]
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *   post:
+ *     summary: Crear un nuevo mazo para el usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - cardIds
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: Mazo Velocidad
+ *               cardIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 example: ["col_set1_card_001", "col_set1_card_002"]
+ *     responses:
+ *       201:
+ *         description: Mazo creado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Mazo creado exitosamente.
+ *                 deck:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: d_xyz789
+ *                     name:
+ *                       type: string
+ *                       example: Mazo Velocidad
+ *                     cardIds:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *       400:
+ *         description: Datos del mazo inválidos o cartas no poseídas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 router.get('/decks', getUserDecks);
 
 // CREAR: 1.Auth -> 2.Formato -> 3.Dueño de cartas -> 4.Controller
 router.post('/decks', validateDeckBody, hasCardsInCollection, createDeck);
 
+/**
+ * @swagger
+ * /api/users/decks/{deckId}:
+ *   put:
+ *     summary: Actualizar un mazo existente del usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: deckId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID del mazo a actualizar (debe comenzar con "d_")
+ *         example: d_xyz789
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - cardIds
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: Mazo Velocidad v2
+ *               cardIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 example: ["col_set1_card_001", "col_set1_card_005"]
+ *     responses:
+ *       200:
+ *         description: Mazo actualizado correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Mazo actualizado.
+ *                 deck:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                       example: d_xyz789
+ *                     name:
+ *                       type: string
+ *                       example: Mazo Velocidad v2
+ *       400:
+ *         description: ID inválido, datos del mazo inválidos o cartas no poseídas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: El mazo no pertenece al usuario autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *   delete:
+ *     summary: Eliminar un mazo del usuario autenticado
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: deckId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID del mazo a eliminar (debe comenzar con "d_")
+ *         example: d_xyz789
+ *     responses:
+ *       200:
+ *         description: Mazo eliminado correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Mazo eliminado correctamente.
+ *       400:
+ *         description: ID de mazo inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: No autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: El mazo no pertenece al usuario autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 // ACTUALIZAR: 1.Auth -> 2.Dueño del mazo -> 3.Formato -> 4.Dueño de cartas -> 5.Controller
 router.put(
   '/decks/:deckId',

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -6,7 +6,7 @@ import jwt from 'jsonwebtoken';
 const mockDb = {
   User: {
     findOne: async (query: any) => null, // Simula que no encuentra usuarios duplicados por defecto
-    create: async (data: any) => ({ id: 'new_user_123', ...data }),
+    create: async (data: any) => ({ id: 'u_123', ...data }),
   },
 };
 

--- a/src/services/shop.service.ts
+++ b/src/services/shop.service.ts
@@ -65,7 +65,7 @@ export const ShopService = {
     const userEconomy = await mockDb.Economy.findByUserId(userId);
     if (userEconomy.coins < item.price) {
       throw {
-        status: 400,
+        status: 403,
         message: 'Fondos insuficientes.',
         required: item.price,
         currentBalance: userEconomy.coins,


### PR DESCRIPTION
## Descripción
- Se ha añadido documentación Swagger detallada para todos los endpoints de los directorios del backend (excepto services).
- Incluye anotaciones JSDoc en los ficheros de rutas, definición de esquemas y seguridad JWT.
- Permite la generación automática de la documentación en /api-docs.

La api está abierta a cambios, sobre todo a nivel de datos que devuelve, ya que eso depende de la BD. 

[http://localhost:3000/api-docs](https://www.google.com/search?q=http://localhost:3000/api-docs)
Ahí se puede consultar los endpoints.

No hacer `npm run build`, no funcionará porque los linters dan errores que corregiré cuando estén más cosas integradas.